### PR TITLE
add repository to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Chris Arderne <chris@rdrn.me"]
 description = "beancount clone in Rust"
 version = "0.0.999"  # set by Github Actions CI
 edition = "2021"
+repository = "https://github.com/carderne/bean-rs"
 
 [dependencies]
 chrono = "0.4.31"


### PR DESCRIPTION
to allow https://crates.io/ , https://lib.rs/ and https://rust-digger.code-maven.com/ to link to it
